### PR TITLE
Extract shared Renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,54 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboardApproval",
-    ":disableDigestUpdates",
-    ":maintainLockFilesWeekly",
-    ":semanticCommitsDisabled",
-    "helpers:pinGitHubActionDigestsToSemver"
-  ],
-  "postUpdateOptions": ["pnpmDedupe"],
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 1,
+  "extends": ["github>kachkaev/reusable-stuff"],
   "rangeStrategy": "bump",
-  "timezone": "Etc/UTC",
   "packageRules": [
     {
+      "description": "Peer dependency ranges describe compatibility, not a version choice, so there is nothing for Renovate to update",
       "enabled": false,
       "matchManagers": ["npm"],
       "matchDepTypes": ["peerDependencies"]
-    },
-    {
-      "autoApprove": true,
-      "automerge": true,
-      "dependencyDashboardApproval": false,
-      "enabled": true,
-      "minimumReleaseAge": "2 days",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["/^pnpm$/"],
-      "schedule": ["every weekend"]
-    },
-    {
-      "autoApprove": true,
-      "automerge": true,
-      "dependencyDashboardApproval": false,
-      "enabled": true,
-      "matchUpdateTypes": ["patch"],
-      "matchCurrentValue": "!/^0\\./",
-      "matchManagers": ["npm"],
-      "minimumReleaseAge": "2 days",
-      "schedule": ["every weekend"]
-    },
-    {
-      "autoApprove": true,
-      "automerge": true,
-      "dependencyDashboardApproval": false,
-      "enabled": true,
-      "matchDepTypes": ["devDependencies"],
-      "matchManagers": ["npm"],
-      "minimumReleaseAge": "2 days",
-      "schedule": ["every weekend"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Routine npm packages: `packages/*/README.md`.
 
 Agent skills: `skills/*/SKILL.md`.
+
+Shared Renovate preset: `default.json` (consumed as `github>kachkaev/reusable-stuff`).

--- a/default.json
+++ b/default.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate preset for kachkaev’s repos, consumed as `github>kachkaev/reusable-stuff`. The top-level `minimumReleaseAge` is the floor that keeps Renovate from proposing a version pnpm would refuse to lock, so it must stay in sync with the same option in each repo’s pnpm-workspace.yaml. Rules below may raise it, never lower it.",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboardApproval",
+    ":disableDigestUpdates",
+    ":maintainLockFilesWeekly",
+    ":semanticCommitsDisabled",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "minimumReleaseAge": "8 hours",
+  "packageRules": [
+    {
+      "autoApprove": true,
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "enabled": true,
+      "minimumReleaseAge": "2 days",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^pnpm$/"],
+      "schedule": ["every weekend"]
+    },
+    {
+      "autoApprove": true,
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "enabled": true,
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentValue": "!/^0\\./",
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "2 days",
+      "schedule": ["every weekend"]
+    },
+    {
+      "autoApprove": true,
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "enabled": true,
+      "matchDepTypes": ["devDependencies"],
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "2 days",
+      "schedule": ["every weekend"]
+    },
+    {
+      "autoApprove": true,
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "enabled": true,
+      "matchManagers": ["github-actions"],
+      "minimumReleaseAge": "2 days",
+      "schedule": ["every weekend"]
+    }
+  ],
+  "postUpdateOptions": ["pnpmDedupe"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 1,
+  "rangeStrategy": "pin",
+  "timezone": "Etc/UTC"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,12 @@ ignorePatchFailures: false
 
 linkWorkspacePackages: true
 
+## Install packages only after they have been out for at least 8 hours, to reduce exposure to
+## malicious releases that get unpublished quickly. Must stay in sync with the `minimumReleaseAge`
+## floor in the Renovate preset (default.json), so that Renovate never proposes a version pnpm
+## would then refuse to lock.
+minimumReleaseAge: 480
+
 nodeLinker: isolated
 
 packages:


### PR DESCRIPTION
This PR extracts the Renovate config shared across kachkaev's active repos into a root `default.json` preset, consumable as `github>kachkaev/reusable-stuff`, and switches this repo's own `.github/renovate.json` to a few-liner that extends it (keeping the `rangeStrategy: bump` and peerDependencies deviations).

The trunk is the union of what the six recently-touched repos (occasionner, website, repo-dive, suppress-exit-code, njt, reusable-stuff) already agree on, taking the most recently edited configs as the reference: the six `extends` presets, `minimumReleaseAge: "8 hours"` as the floor synced with pnpm's setting, the three npm automerge rules plus occasionner's github-actions automerge rule, `pnpmDedupe`, PR limits, `rangeStrategy: pin` and UTC timezone.

It also sets `minimumReleaseAge: 480` in this repo's `pnpm-workspace.yaml`, which was silently on pnpm 11's 24-hour default — bringing it to the preferred 8 hours and in sync with the Renovate floor.

Once merged, the other repos can each be reduced to a one-liner (occasionner, website, njt) or a short config keeping only their genuine deviations (repo-dive's monorepo groups, suppress-exit-code's node-version rules and `dependencies` range strategy).